### PR TITLE
Support for compression info

### DIFF
--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -1,4 +1,5 @@
 import baseFetch from "isomorphic-unfetch";
+import Link from "next/link";
 
 /**
  * Return a `fetch` implementation and a function that will return the full HAR
@@ -170,6 +171,12 @@ export default function DemoPage({ harData }) {
           </a>
         </div>
       ) : null}
+      <p>
+        <Link href="/">
+          <a>Send requests in browser</a>
+        </Link>{" "}
+        for comparison
+      </p>
       <pre>{JSON.stringify(harData, null, 2)}</pre>
     </main>
   );

--- a/test.js
+++ b/test.js
@@ -417,6 +417,34 @@ fragment TypeRef on __Type {
             ]
           });
         });
+
+        it("supports compression savings detection (gzip)", async () => {
+          const fetch = withHar(baseFetch);
+          const response = await fetch("https://postman-echo.com/gzip");
+          const body = await response.json();
+          expect(body.gzipped).toBe(true);
+          expect(response.harEntry.response.bodySize).toBeLessThan(
+            response.harEntry.response.content.size
+          );
+          expect(response.harEntry.response.content.compression).toBe(
+            response.harEntry.response.content.size -
+              response.harEntry.response.bodySize
+          );
+        });
+
+        it("supports compression savings detection (deflate)", async () => {
+          const fetch = withHar(baseFetch);
+          const response = await fetch("https://postman-echo.com/deflate");
+          const body = await response.json();
+          expect(body.deflated).toBe(true);
+          expect(response.harEntry.response.bodySize).toBeLessThan(
+            response.harEntry.response.content.size
+          );
+          expect(response.harEntry.response.content.compression).toBe(
+            response.harEntry.response.content.size -
+              response.harEntry.response.bodySize
+          );
+        });
       });
 
       it("reports entries with the onHarEntry option", async () => {


### PR DESCRIPTION
* Support for the `compression` field.
* Use high resolution timestamps via `process.hrtime`.
* Count bytes instead of string length where possible.