### PR TITLE
Gracefully handle malformed Set-Cookie headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,12 @@ function buildResponseCookies(headers) {
   const setCookies = headers["set-cookie"];
   if (setCookies) {
     setCookies.forEach(headerValue => {
-      const parsed = setCookie.parse(headerValue);
+      let parsed;
+      try {
+        parsed = setCookie.parse(headerValue);
+      } catch (err) {
+        return;
+      }
       parsed.forEach(cookie => {
         const { name, value, path, domain, expires, httpOnly, secure } = cookie;
         const harCookie = {

--- a/test.js
+++ b/test.js
@@ -445,6 +445,15 @@ fragment TypeRef on __Type {
               response.harEntry.response.bodySize
           );
         });
+
+        it("ignores malformed Set-Cookie headers instead of throwing an error", async () => {
+          const fetch = withHar(baseFetch);
+          await expect(
+            fetch(
+              "https://postman-echo.com/response-headers?Content-Type=text/html&Set-Cookie=%3Da%3D5%25%25"
+            )
+          ).resolves.toHaveProperty("harEntry");
+        });
       });
 
       it("reports entries with the onHarEntry option", async () => {


### PR DESCRIPTION
Skip bogus `Set-Cookie` headers.

Both `cookie` and `querystring` seem to already gracefully handle bogus input.