### PR TITLE
Support custom agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ Additionally, `params` will only be populated if the `Content-Type` is exactly
 
 There may be limited support for exotic request body encodings.
 
+### Custom Agent
+
+This library works by using the custom `agent` option supported by `node-fetch`.
+However, it should still work if you pass your own custom `agent` as well. The
+provided agent instance will have its `addRequest` method instrumented with the
+necessary HAR tracking behavior. This behavior will be skipped if the request
+does not originate from a Fetch instance returned by `withHar`.
+
 ### Page Info
 
 The second argument to `createHarLog` allows you to add some initial page info:

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -1,5 +1,10 @@
 import baseFetch from "isomorphic-unfetch";
+import { HttpsAgent } from "agentkeepalive";
 import Link from "next/link";
+
+// Supports custom agents!
+// This is not required but is for demonstration purposes.
+const httpsAgent = new HttpsAgent({});
 
 /**
  * Return a `fetch` function and a HAR log that will collect any entries
@@ -24,9 +29,10 @@ DemoPage.getInitialProps = async ctx => {
   // to all pages.
   const [fetch, harData] = createFetch({ title: "Demo Page" });
 
-  await fetch("https://httpstat.us/200");
+  await fetch("https://httpstat.us/200", { agent: httpsAgent });
 
   await fetch("https://graphbrainz.herokuapp.com/", {
+    agent: httpsAgent,
     method: "POST",
     headers: {
       "Content-Type": "application/json"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "set-cookie-parser": "^2.3.5"
   },
   "devDependencies": {
+    "agentkeepalive": "^4.0.2",
     "coveralls": "^3.0.4",
     "cross-fetch": "^3.0.4",
     "eslint": "^5.16.0",

--- a/test/cross-fetch.test.js
+++ b/test/cross-fetch.test.js
@@ -1,6 +1,3 @@
-const baseFetch = require("cross-fetch");
 const defineTests = require("./tests");
 
-describe("using cross-fetch", () => {
-  defineTests(baseFetch);
-});
+defineTests("cross-fetch");

--- a/test/isomorphic-fetch.test.js
+++ b/test/isomorphic-fetch.test.js
@@ -1,6 +1,3 @@
-const baseFetch = require("isomorphic-fetch");
 const defineTests = require("./tests");
 
-describe("using isomorphic-fetch", () => {
-  defineTests(baseFetch);
-});
+defineTests("isomorphic-fetch");

--- a/test/isomorphic-unfetch.test.js
+++ b/test/isomorphic-unfetch.test.js
@@ -1,6 +1,3 @@
-const baseFetch = require("isomorphic-unfetch");
 const defineTests = require("./tests");
 
-describe("using isomorphic-unfetch", () => {
-  defineTests(baseFetch);
-});
+defineTests("isomorphic-unfetch");

--- a/test/node-fetch.test.js
+++ b/test/node-fetch.test.js
@@ -1,6 +1,3 @@
-const baseFetch = require("node-fetch");
 const defineTests = require("./tests");
 
-describe("using node-fetch", () => {
-  defineTests(baseFetch);
-});
+defineTests("node-fetch");

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,186 +1,220 @@
+const HttpAgent = require("agentkeepalive");
 const { withHar, createHarLog } = require("../index");
 
-function defineTests(baseFetch) {
+const { HttpsAgent } = HttpAgent;
+
+function spyWithProperties(fn) {
+  const spy = jest.fn(fn);
+  for (const key in fn) {
+    spy[key] = fn[key];
+  }
+  return spy;
+}
+
+function defineTests(packageName) {
+  const baseFetch = spyWithProperties(require(packageName));
   const supportsHeaders = baseFetch.Headers || global.Headers;
   const supportsRequest = baseFetch.Request || global.Request;
 
-  describe("fetch", () => {
-    it("adds harEntry to responses", async () => {
-      const fetch = withHar(baseFetch);
-      const response = await fetch(
-        "https://postman-echo.com/get?foo1=bar1&foo2=bar2",
-        {
-          compress: false,
-          headers: {
-            Cookie: "token=12345; other=abcdef"
+  describe(`using ${packageName}`, () => {
+    beforeEach(() => {
+      jest.spyOn(withHar.harEntryMap, "get");
+      jest.spyOn(withHar.harEntryMap, "set");
+      jest.spyOn(withHar.harEntryMap, "delete");
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      expect(withHar.harEntryMap.size).toBe(0);
+    });
+
+    describe("fetch", () => {
+      it("adds harEntry to responses", async () => {
+        const fetch = withHar(baseFetch);
+        const response = await fetch(
+          "https://postman-echo.com/get?foo1=bar1&foo2=bar2",
+          {
+            compress: false,
+            headers: {
+              Cookie: "token=12345; other=abcdef"
+            }
           }
-        }
-      );
-      expect(response.headers.get("content-type")).toBe(
-        "application/json; charset=utf-8"
-      );
-      expect(response.harEntry).toEqual({
-        _timestamps: expect.any(Object),
-        startedDateTime: expect.stringMatching(
-          /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z$/
-        ),
-        time: expect.any(Number),
-        timings: {
-          blocked: expect.any(Number),
-          connect: expect.any(Number),
-          dns: expect.any(Number),
-          receive: expect.any(Number),
-          send: expect.any(Number),
-          ssl: expect.any(Number),
-          wait: expect.any(Number)
-        },
-        cache: {
-          afterRequest: null,
-          beforeRequest: null
-        },
-        pageref: "page_1",
-        request: {
-          bodySize: -1,
-          cookies: [
-            { name: "token", value: "12345" },
-            { name: "other", value: "abcdef" }
-          ],
-          headers: expect.arrayContaining([
-            {
-              name: expect.stringMatching(/^cookie$/i),
-              value: "token=12345; other=abcdef"
-            },
-            {
-              name: "x-har-request-id",
-              value: expect.any(String)
-            },
-            {
-              name: expect.stringMatching(/^accept$/i),
-              value: "*/*"
-            },
-            {
-              name: expect.stringMatching(/^user-agent$/i),
-              value: "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            }
-          ]),
-          headersSize: -1,
-          httpVersion: "HTTP/1.1",
-          method: "GET",
-          queryString: [
-            {
-              name: "foo1",
-              value: "bar1"
-            },
-            {
-              name: "foo2",
-              value: "bar2"
-            }
-          ],
-          url: "https://postman-echo.com/get?foo1=bar1&foo2=bar2"
-        },
-        response: {
-          httpVersion: "HTTP/1.1",
-          status: 200,
-          statusText: "OK",
-          redirectURL: "",
-          headersSize: -1,
-          bodySize: expect.any(Number),
-          content: {
-            mimeType: "application/json; charset=utf-8",
-            size: expect.any(Number),
-            text: expect.any(String)
+        );
+        expect(response.headers.get("content-type")).toBe(
+          "application/json; charset=utf-8"
+        );
+        expect(response.harEntry).toEqual({
+          _timestamps: expect.any(Object),
+          startedDateTime: expect.stringMatching(
+            /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d+Z$/
+          ),
+          time: expect.any(Number),
+          timings: {
+            blocked: expect.any(Number),
+            connect: expect.any(Number),
+            dns: expect.any(Number),
+            receive: expect.any(Number),
+            send: expect.any(Number),
+            ssl: expect.any(Number),
+            wait: expect.any(Number)
           },
-          cookies: expect.any(Array),
-          headers: expect.arrayContaining([
-            {
-              name: "Content-Type",
-              value: "application/json; charset=utf-8"
+          cache: {
+            afterRequest: null,
+            beforeRequest: null
+          },
+          pageref: "page_1",
+          request: {
+            bodySize: -1,
+            cookies: [
+              { name: "token", value: "12345" },
+              { name: "other", value: "abcdef" }
+            ],
+            headers: expect.arrayContaining([
+              {
+                name: expect.stringMatching(/^cookie$/i),
+                value: "token=12345; other=abcdef"
+              },
+              {
+                name: "x-har-request-id",
+                value: expect.any(String)
+              },
+              {
+                name: expect.stringMatching(/^accept$/i),
+                value: "*/*"
+              },
+              {
+                name: expect.stringMatching(/^user-agent$/i),
+                value: "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+              }
+            ]),
+            headersSize: -1,
+            httpVersion: "HTTP/1.1",
+            method: "GET",
+            queryString: [
+              {
+                name: "foo1",
+                value: "bar1"
+              },
+              {
+                name: "foo2",
+                value: "bar2"
+              }
+            ],
+            url: "https://postman-echo.com/get?foo1=bar1&foo2=bar2"
+          },
+          response: {
+            httpVersion: "HTTP/1.1",
+            status: 200,
+            statusText: "OK",
+            redirectURL: "",
+            headersSize: -1,
+            bodySize: expect.any(Number),
+            content: {
+              mimeType: "application/json; charset=utf-8",
+              size: expect.any(Number),
+              text: expect.any(String)
             },
-            {
-              name: "Date",
-              value: expect.any(String)
-            },
-            {
-              name: "Vary",
-              value: "Accept-Encoding"
-            },
-            {
-              name: "Content-Length",
-              value: expect.any(String)
-            },
-            {
-              name: "Connection",
-              value: "Close"
-            }
-          ])
-        }
+            cookies: expect.any(Array),
+            headers: expect.arrayContaining([
+              {
+                name: "Content-Type",
+                value: "application/json; charset=utf-8"
+              },
+              {
+                name: "Date",
+                value: expect.any(String)
+              },
+              {
+                name: "Vary",
+                value: "Accept-Encoding"
+              },
+              {
+                name: "Content-Length",
+                value: expect.any(String)
+              },
+              {
+                name: "Connection",
+                value: "Close"
+              }
+            ])
+          }
+        });
+        const body = await response.json();
+        expect(body).toEqual({
+          args: {
+            foo1: "bar1",
+            foo2: "bar2"
+          },
+          headers: {
+            accept: "*/*",
+            cookie: "token=12345; other=abcdef",
+            host: "postman-echo.com",
+            "user-agent":
+              "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https",
+            "x-har-request-id": expect.any(String)
+          },
+          url: "https://postman-echo.com/get?foo1=bar1&foo2=bar2"
+        });
       });
-      const body = await response.json();
-      expect(body).toEqual({
-        args: {
-          foo1: "bar1",
-          foo2: "bar2"
-        },
-        headers: {
-          accept: "*/*",
-          cookie: "token=12345; other=abcdef",
-          host: "postman-echo.com",
-          "user-agent":
-            "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
-          "x-forwarded-port": "443",
-          "x-forwarded-proto": "https",
-          "x-har-request-id": expect.any(String)
-        },
-        url: "https://postman-echo.com/get?foo1=bar1&foo2=bar2"
-      });
-    });
 
-    it("reports entries with the onHarEntry option", async () => {
-      const onHarEntry = jest.fn();
-      const fetch = withHar(baseFetch);
-      await fetch("https://postman-echo.com/get", { onHarEntry });
-      expect(onHarEntry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          request: expect.objectContaining({
-            url: "https://postman-echo.com/get"
+      it("reports entries with the onHarEntry option", async () => {
+        const onHarEntry = jest.fn();
+        const fetch = withHar(baseFetch);
+        await fetch("https://postman-echo.com/get", { onHarEntry });
+        expect(onHarEntry).toHaveBeenCalledWith(
+          expect.objectContaining({
+            request: expect.objectContaining({
+              url: "https://postman-echo.com/get"
+            })
           })
-        })
-      );
-    });
-
-    it("adds entries to the given log created with createHarLog", async () => {
-      const har = createHarLog();
-      const har2 = createHarLog();
-      const fetch = withHar(baseFetch);
-      await Promise.all([
-        fetch("https://postman-echo.com/stream/5", { har }),
-        fetch("https://postman-echo.com/delay/2", { har: har2 }),
-        fetch("https://postman-echo.com/deflate", { har })
-      ]);
-      expect(har.log.entries).toHaveLength(2);
-      expect(har2.log.entries).toHaveLength(1);
-    });
-
-    it("does not record entries if har option is false", async () => {
-      const onHarEntry = jest.fn();
-      const fetch = withHar(baseFetch);
-      const response = await fetch("https://postman-echo.com/get", {
-        har: false,
-        onHarEntry
+        );
       });
-      expect(onHarEntry).not.toHaveBeenCalled();
-      expect(response).not.toHaveProperty("harEntry");
-    });
 
-    it("supports large request and response bodies", async () => {
-      const fetch = withHar(baseFetch);
-      const response = await fetch("https://graphbrainz.herokuapp.com/", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-          query: `
+      it("adds entries to the given log created with createHarLog", async () => {
+        const har = createHarLog();
+        const har2 = createHarLog();
+        const fetch = withHar(baseFetch);
+        await Promise.all([
+          fetch("https://postman-echo.com/stream/5", { har }),
+          fetch("https://postman-echo.com/delay/2", { har: har2 }),
+          fetch("https://postman-echo.com/deflate", { har })
+        ]);
+        expect(har.log.entries).toHaveLength(2);
+        expect(har2.log.entries).toHaveLength(1);
+      });
+
+      it("does not record entries if har option is false", async () => {
+        const onHarEntry = jest.fn();
+        const fetch = withHar(baseFetch);
+        const response = await fetch("https://postman-echo.com/get", {
+          har: false,
+          onHarEntry
+        });
+        expect(onHarEntry).not.toHaveBeenCalled();
+        expect(response).not.toHaveProperty("harEntry");
+      });
+
+      it("works with both HTTP and HTTPS", async () => {
+        const fetch = withHar(baseFetch);
+        const httpResponse = await fetch("http://postman-echo.com/get");
+        const httpsResponse = await fetch("https://postman-echo.com/get");
+        expect(httpResponse.ok).toBe(true);
+        expect(httpsResponse.ok).toBe(true);
+        expect(httpResponse).toHaveProperty("harEntry");
+        expect(httpsResponse).toHaveProperty("harEntry");
+      });
+
+      it("supports large request and response bodies", async () => {
+        const fetch = withHar(baseFetch);
+        const response = await fetch("https://graphbrainz.herokuapp.com/", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            query: `
 query IntrospectionQuery {
   __schema {
     queryType { name }
@@ -273,210 +307,225 @@ fragment TypeRef on __Type {
   }
 }
 `
-        })
-      });
-      const body = await response.json();
-      expect(body).toMatchObject({
-        data: {
-          __schema: expect.any(Object)
-        }
-      });
-    });
-
-    it("fails gracefully if fetch unsets our request ID header", async () => {
-      function customFetch(input, options) {
-        // Remove `x-har-request-id`.
-        const headers = { ...options.headers };
-        delete headers["x-har-request-id"];
-        return baseFetch(input, { ...options, headers });
-      }
-      const fetch = withHar(customFetch);
-      const response = await fetch("https://postman-echo.com/get");
-      expect(response).not.toHaveProperty("harEntry");
-    });
-
-    it("removes the entry from the entry map on success", async () => {
-      const harEntryMap = new Map();
-      jest.spyOn(harEntryMap, "get");
-      jest.spyOn(harEntryMap, "set");
-      jest.spyOn(harEntryMap, "delete");
-      const fetch = withHar(baseFetch, { harEntryMap });
-      await fetch("https://postman-echo.com/get");
-      expect(harEntryMap.set).toHaveBeenCalled();
-      expect(harEntryMap.delete).toHaveBeenCalled();
-      expect(harEntryMap.size).toBe(0);
-    });
-
-    it("removes the entry from the entry map on failure", async () => {
-      const harEntryMap = new Map();
-      jest.spyOn(harEntryMap, "get");
-      jest.spyOn(harEntryMap, "set");
-      jest.spyOn(harEntryMap, "delete");
-      const fetch = withHar(baseFetch, { harEntryMap });
-      await expect(
-        fetch(
-          "https://httpbin.org/redirect-to?url=https://github.com/exogen&status_code=302",
-          {
-            redirect: "error"
+          })
+        });
+        const body = await response.json();
+        expect(body).toMatchObject({
+          data: {
+            __schema: expect.any(Object)
           }
-        )
-      ).rejects.toThrow();
-      expect(harEntryMap.set).toHaveBeenCalled();
-      expect(harEntryMap.delete).toHaveBeenCalled();
-      expect(harEntryMap.size).toBe(0);
-    });
-
-    it("records multiple entries and populates redirectURL on redirects", async () => {
-      const har = createHarLog();
-      const onHarEntry = jest.fn();
-      const fetch = withHar(baseFetch, { har, onHarEntry });
-      const response = await fetch(
-        "https://httpbin.org/redirect-to?url=https://github.com/exogen&status_code=302"
-      );
-      expect(har.log.entries).toHaveLength(2);
-      const [firstEntry, secondEntry] = har.log.entries;
-      expect(firstEntry.response.status).toBe(302);
-      expect(firstEntry.response.redirectURL).toBe("https://github.com/exogen");
-      expect(secondEntry).toBe(response.harEntry);
-      expect(response.harEntry.request.url).toBe("https://github.com/exogen");
-      expect(response.harEntry.response.status).toBe(200);
-      expect(response.harEntry.response.redirectURL).toBe("");
-      expect(onHarEntry).toHaveBeenCalledTimes(2);
-      expect(onHarEntry).toHaveBeenNthCalledWith(1, firstEntry);
-      expect(onHarEntry).toHaveBeenNthCalledWith(2, secondEntry);
-    });
-
-    (supportsHeaders ? it : it.skip)(
-      "works when headers are a Headers object",
-      async () => {
-        const Headers = baseFetch.Headers || global.Headers;
-        const headers = new Headers();
-        headers.set("X-Test-Foo", "foo");
-        headers.set("X-Test-Bar", "bar");
-        const fetch = withHar(baseFetch);
-        const response = await fetch("https://httpbin.org/status/201", {
-          headers
         });
-        expect(response.harEntry.request.url).toBe(
-          "https://httpbin.org/status/201"
-        );
-      }
-    );
+      });
 
-    (supportsRequest ? it : it.skip)(
-      "works when the input is a Request object",
-      async () => {
-        const Request = baseFetch.Request || global.Request;
-        const request = new Request("https://postman-echo.com/post", {
+      it("fails gracefully if fetch unsets our request ID header", async () => {
+        function customFetch(input, options) {
+          // Remove `x-har-request-id`.
+          const headers = { ...options.headers };
+          delete headers["x-har-request-id"];
+          return baseFetch(input, { ...options, headers });
+        }
+        const fetch = withHar(customFetch);
+        const response = await fetch("https://postman-echo.com/get");
+        expect(response).not.toHaveProperty("harEntry");
+      });
+
+      it("removes the entry from the entry map on success", async () => {
+        const fetch = withHar(baseFetch);
+        await fetch("https://postman-echo.com/get");
+        expect(withHar.harEntryMap.set).toHaveBeenCalled();
+        expect(withHar.harEntryMap.delete).toHaveBeenCalled();
+        expect(withHar.harEntryMap.size).toBe(0);
+      });
+
+      it("removes the entry from the entry map on failure", async () => {
+        const fetch = withHar(baseFetch);
+        await expect(
+          fetch(
+            "https://httpbin.org/redirect-to?url=https://github.com/exogen&status_code=302",
+            {
+              redirect: "error"
+            }
+          )
+        ).rejects.toThrow();
+        expect(withHar.harEntryMap.set).toHaveBeenCalled();
+        expect(withHar.harEntryMap.delete).toHaveBeenCalled();
+        expect(withHar.harEntryMap.size).toBe(0);
+      });
+
+      it("records multiple entries and populates redirectURL on redirects", async () => {
+        const har = createHarLog();
+        const onHarEntry = jest.fn();
+        const fetch = withHar(baseFetch, { har, onHarEntry });
+        const response = await fetch(
+          "https://httpbin.org/redirect-to?url=https://github.com/exogen&status_code=302"
+        );
+        expect(har.log.entries).toHaveLength(2);
+        const [firstEntry, secondEntry] = har.log.entries;
+        expect(firstEntry.response.status).toBe(302);
+        expect(firstEntry.response.redirectURL).toBe(
+          "https://github.com/exogen"
+        );
+        expect(secondEntry).toBe(response.harEntry);
+        expect(response.harEntry.request.url).toBe("https://github.com/exogen");
+        expect(response.harEntry.response.status).toBe(200);
+        expect(response.harEntry.response.redirectURL).toBe("");
+        expect(onHarEntry).toHaveBeenCalledTimes(2);
+        expect(onHarEntry).toHaveBeenNthCalledWith(1, firstEntry);
+        expect(onHarEntry).toHaveBeenNthCalledWith(2, secondEntry);
+      });
+
+      (supportsHeaders ? it : it.skip)(
+        "works when headers are a Headers object",
+        async () => {
+          const Headers = baseFetch.Headers || global.Headers;
+          const headers = new Headers();
+          headers.set("X-Test-Foo", "foo");
+          headers.set("X-Test-Bar", "bar");
+          const fetch = withHar(baseFetch);
+          const response = await fetch("https://httpbin.org/status/201", {
+            headers
+          });
+          expect(response.harEntry.request.url).toBe(
+            "https://httpbin.org/status/201"
+          );
+        }
+      );
+
+      (supportsRequest ? it : it.skip)(
+        "works when the input is a Request object",
+        async () => {
+          const Request = baseFetch.Request || global.Request;
+          const request = new Request("https://postman-echo.com/post", {
+            method: "POST",
+            body: "test"
+          });
+          const fetch = withHar(baseFetch);
+          const response = await fetch(request);
+          expect(response.harEntry.request.url).toBe(
+            "https://postman-echo.com/post"
+          );
+          expect(response.harEntry.request.method).toBe("POST");
+        }
+      );
+
+      it("records request body info", async () => {
+        const fetch = withHar(baseFetch);
+        const response = await fetch("https://postman-echo.com/post", {
           method: "POST",
-          body: "test"
+          headers: {
+            "Content-Type": "text/plain"
+          },
+          body: "test one two!"
         });
+        expect(response.harEntry.request.bodySize).toBe(13);
+        expect(response.harEntry.request.postData).toEqual({
+          mimeType: "text/plain",
+          text: "test one two!"
+        });
+      });
+
+      it("records request body params", async () => {
         const fetch = withHar(baseFetch);
-        const response = await fetch(request);
-        expect(response.harEntry.request.url).toBe(
-          "https://postman-echo.com/post"
+        const response = await fetch("https://postman-echo.com/post", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          body: "foo=1&bar=2&bar=three%20aka%203&baz=4"
+        });
+        expect(response.harEntry.request.bodySize).toBe(37);
+        expect(response.harEntry.request.postData).toEqual({
+          mimeType: "application/x-www-form-urlencoded",
+          params: [
+            { name: "foo", value: "1" },
+            { name: "bar", value: "2" },
+            { name: "bar", value: "three aka 3" },
+            { name: "baz", value: "4" }
+          ]
+        });
+      });
+
+      it("supports compression savings detection (gzip)", async () => {
+        const fetch = withHar(baseFetch);
+        const response = await fetch("https://postman-echo.com/gzip");
+        const body = await response.json();
+        expect(body.gzipped).toBe(true);
+        expect(response.harEntry.response.bodySize).toBeLessThan(
+          response.harEntry.response.content.size
         );
-        expect(response.harEntry.request.method).toBe("POST");
-      }
-    );
-
-    it("records request body info", async () => {
-      const fetch = withHar(baseFetch);
-      const response = await fetch("https://postman-echo.com/post", {
-        method: "POST",
-        headers: {
-          "Content-Type": "text/plain"
-        },
-        body: "test one two!"
+        expect(response.harEntry.response.content.compression).toBe(
+          response.harEntry.response.content.size -
+            response.harEntry.response.bodySize
+        );
       });
-      expect(response.harEntry.request.bodySize).toBe(13);
-      expect(response.harEntry.request.postData).toEqual({
-        mimeType: "text/plain",
-        text: "test one two!"
+
+      it("supports compression savings detection (deflate)", async () => {
+        const fetch = withHar(baseFetch);
+        const response = await fetch("https://postman-echo.com/deflate");
+        const body = await response.json();
+        expect(body.deflated).toBe(true);
+        expect(response.harEntry.response.bodySize).toBeLessThan(
+          response.harEntry.response.content.size
+        );
+        expect(response.harEntry.response.content.compression).toBe(
+          response.harEntry.response.content.size -
+            response.harEntry.response.bodySize
+        );
+      });
+
+      it("ignores malformed Set-Cookie headers instead of throwing an error", async () => {
+        const fetch = withHar(baseFetch);
+        await expect(
+          fetch(
+            "https://postman-echo.com/response-headers?Content-Type=text/html&Set-Cookie=%3Da%3D5%25%25"
+          )
+        ).resolves.toHaveProperty("harEntry");
+      });
+
+      it("supports custom agents", async () => {
+        const httpAgent = new HttpAgent();
+        const httpsAgent = new HttpsAgent();
+        const fetch = withHar(baseFetch);
+        const httpResponse = await fetch("http://postman-echo.com/get", {
+          agent: httpAgent
+        });
+        const httpsResponse = await fetch("https://postman-echo.com/get", {
+          agent: httpsAgent
+        });
+        expect(httpResponse.harEntry.response.headers).toContainEqual({
+          name: expect.stringMatching(/^connection/i),
+          value: "keep-alive"
+        });
+        expect(httpsResponse.harEntry.response.headers).toContainEqual({
+          name: expect.stringMatching(/^connection/i),
+          value: "keep-alive"
+        });
       });
     });
 
-    it("records request body params", async () => {
-      const fetch = withHar(baseFetch);
-      const response = await fetch("https://postman-echo.com/post", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded"
-        },
-        body: "foo=1&bar=2&bar=three%20aka%203&baz=4"
-      });
-      expect(response.harEntry.request.bodySize).toBe(37);
-      expect(response.harEntry.request.postData).toEqual({
-        mimeType: "application/x-www-form-urlencoded",
-        params: [
-          { name: "foo", value: "1" },
-          { name: "bar", value: "2" },
-          { name: "bar", value: "three aka 3" },
-          { name: "baz", value: "4" }
-        ]
-      });
-    });
-
-    it("supports compression savings detection (gzip)", async () => {
-      const fetch = withHar(baseFetch);
-      const response = await fetch("https://postman-echo.com/gzip");
-      const body = await response.json();
-      expect(body.gzipped).toBe(true);
-      expect(response.harEntry.response.bodySize).toBeLessThan(
-        response.harEntry.response.content.size
-      );
-      expect(response.harEntry.response.content.compression).toBe(
-        response.harEntry.response.content.size -
-          response.harEntry.response.bodySize
-      );
-    });
-
-    it("supports compression savings detection (deflate)", async () => {
-      const fetch = withHar(baseFetch);
-      const response = await fetch("https://postman-echo.com/deflate");
-      const body = await response.json();
-      expect(body.deflated).toBe(true);
-      expect(response.harEntry.response.bodySize).toBeLessThan(
-        response.harEntry.response.content.size
-      );
-      expect(response.harEntry.response.content.compression).toBe(
-        response.harEntry.response.content.size -
-          response.harEntry.response.bodySize
-      );
-    });
-
-    it("ignores malformed Set-Cookie headers instead of throwing an error", async () => {
-      const fetch = withHar(baseFetch);
-      await expect(
-        fetch(
-          "https://postman-echo.com/response-headers?Content-Type=text/html&Set-Cookie=%3Da%3D5%25%25"
-        )
-      ).resolves.toHaveProperty("harEntry");
-    });
-  });
-
-  it("reports entries with the onHarEntry option", async () => {
-    const onHarEntry = jest.fn();
-    const fetch = withHar(baseFetch, { onHarEntry });
-    await fetch("https://postman-echo.com/get");
-    expect(onHarEntry).toHaveBeenCalledWith(
-      expect.objectContaining({
-        request: expect.objectContaining({
-          url: "https://postman-echo.com/get"
+    it("reports entries with the onHarEntry option", async () => {
+      const onHarEntry = jest.fn();
+      const fetch = withHar(baseFetch, { onHarEntry });
+      await fetch("https://postman-echo.com/get");
+      expect(onHarEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            url: "https://postman-echo.com/get"
+          })
         })
-      })
-    );
-  });
+      );
+    });
 
-  it("adds entries to the given log created with createHarLog", async () => {
-    const har = createHarLog();
-    const fetch = withHar(baseFetch, { har });
-    await Promise.all([
-      fetch("https://postman-echo.com/stream/5"),
-      fetch("https://postman-echo.com/delay/2"),
-      fetch("https://postman-echo.com/deflate")
-    ]);
-    expect(har.log.entries).toHaveLength(3);
+    it("adds entries to the given log created with createHarLog", async () => {
+      const har = createHarLog();
+      const fetch = withHar(baseFetch, { har });
+      await Promise.all([
+        fetch("https://postman-echo.com/stream/5"),
+        fetch("https://postman-echo.com/delay/2"),
+        fetch("https://postman-echo.com/deflate")
+      ]);
+      expect(har.log.entries).toHaveLength(3);
+    });
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,15 @@ acorn@^6.0.1, acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
+agentkeepalive@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.0.2.tgz#38a490b779a97bd542d153e5a7da0d1fdef35dd3"
+  integrity sha512-A5gSniD4xMCYtSD4ilUHpQRB9ZbNjtIPittKUv7bA0j0UCwbT3EJBUYLKPJ/dtmaXRYWI2mG4/O90xbi7oahNw==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
+
 ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
@@ -942,6 +951,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+depd@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
 detect-libc@^1.0.2:
   version "1.0.3"
@@ -1538,6 +1552,13 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -2567,7 +2588,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==


### PR DESCRIPTION
* If a custom `agent` is passed, we instrument it instead of creating a `HarHttpAgent` or `HarHttpsAgent` instance.
* A global `HarHttpAgent` or `HarHttpsAgent` (as well as a global `harEntryMap`) are now used for all Fetch instances returned by `withHar`, instead of each call to `withHar` creating its own instances.
* Add tests and demo using `agentkeepalive`.