### PR TITLE
Fix adding listeners to reused sockets by removing them on request finish

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+coverage
+demo/.next

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -141,18 +141,15 @@ fragment TypeRef on __Type {
 function useHarUrl(har) {
   const [downloadUrl, setDownloadUrl] = useState(null);
 
-  useEffect(
-    () => {
-      if (typeof URL !== "undefined" && URL.createObjectURL) {
-        const blob = new Blob([JSON.stringify(har)], {
-          type: "data:application/json;charset=utf-8"
-        });
-        const objectUrl = URL.createObjectURL(blob);
-        setDownloadUrl(objectUrl);
-      }
-    },
-    [har]
-  );
+  useEffect(() => {
+    if (typeof URL !== "undefined" && URL.createObjectURL) {
+      const blob = new Blob([JSON.stringify(har)], {
+        type: "data:application/json;charset=utf-8"
+      });
+      const objectUrl = URL.createObjectURL(blob);
+      setDownloadUrl(objectUrl);
+    }
+  }, [har]);
 
   return downloadUrl;
 }

--- a/index.js
+++ b/index.js
@@ -162,9 +162,9 @@ function handleRequest(request, options) {
     socket.once("secureConnect", onSecureConnect);
 
     removeSocketListeners = () => {
-      socket.off("lookup", onLookup);
-      socket.off("connect", onConnect);
-      socket.off("secureConnect", onSecureConnect);
+      socket.removeListener("lookup", onLookup);
+      socket.removeListener("connect", onConnect);
+      socket.removeListener("secureConnect", onSecureConnect);
     };
   });
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "main": "index.js",
   "scripts": {
     "coveralls": "coveralls < ./coverage/lcov.info",
+    "format": "prettier --write \"**/*.{js,md}\"",
     "lint": "eslint index.js test",
     "start": "cd demo && yarn start",
     "test": "yarn run lint && yarn test:coverage",
@@ -39,6 +40,7 @@
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-unfetch": "^3.0.0",
     "jest": "^24.8.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "prettier": "^1.18.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,6 +3018,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"


### PR DESCRIPTION
This matters when using a KeepAlive agent that uses socket pooling.