### PR TITLE
fix: Retrieving `requestId` from array optionally

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ function handleRequest(request, options) {
   }
 
   const headers = options.headers || {};
-  const requestId = headers[headerName] ? headers[headerName][0] : null;
+  const requestId = headers[headerName] 
+    ? Array.isArray(headers[headerName]) ? headers[headerName][0] : headers[headerName]
+    : null;
 
   if (!requestId) {
     return;


### PR DESCRIPTION
It seems that always accessing the first element doesn't work. Retrieving the `[0]` resulted in getting only a single character from the ID in the header and thus not matching any HAR entry due to that mismatch.

Since I'm not sure why it's even expecting an array, I left the check and logic for that case.